### PR TITLE
chore: reconfigure so project runs on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+save-exact=true

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,23 +1,22 @@
 import prettierConfig from 'eslint-config-prettier';
-import prettierPlugin from 'eslint-plugin-prettier';
+import prettierPlugin from 'eslint-plugin-prettier/recommended';
 import globals from 'globals';
 import js from '@eslint/js';
 
 export default [
     js.configs.recommended,
     prettierConfig,
+    prettierPlugin,
     {
-        plugins: {
-            prettier: prettierPlugin,
-        },
         languageOptions: {
             globals: {
+                ...globals.node,
                 ...globals.browser,
                 global: true,
             },
         },
     },
     {
-        ignores: ['dist/*'],
+        ignores: ['coverage/*', 'dist/*'],
     },
 ];

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
     "types"
   ],
   "scripts": {
-    "prepublishOnly": "npm run build && npm run types",
+    "prepublishOnly": "run-s build types",
     "build": "esbuild src/store.js --outfile=dist/store.js --target=es2017",
     "lint": "eslint . --ignore-pattern '/dist/'",
     "lint:fix": "eslint --fix . --ignore-pattern '/dist/'",
-    "test": "node --test && tsc --project tsconfig.test.json",
+    "test": "run-s test:*",
+    "test:unit": "node --test",
+    "test:types": "tsc --project tsconfig.test.json",
     "types": "tsc --declaration --emitDeclarationOnly"
   },
   "dependencies": {
@@ -49,12 +51,13 @@
     "@semantic-release/npm": "12.0.1",
     "@semantic-release/release-notes-generator": "13.0.0",
     "@types/node": "20.14.9",
-    "esbuild": "^0.21.5",
+    "esbuild": "0.21.5",
     "eslint": "9.1.1",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
     "globals": "15.0.0",
     "jsdom": "24.0.0",
+    "npm-run-all": "4.1.5",
     "prettier": "3.2.5",
     "typescript": "5.4.5"
   }


### PR DESCRIPTION
This is a browser-only package, so skipping the full OS matrix. Still, nice to be able to checkout the repo and do stuff on Windows.