### PR TITLE
feat: add cjs export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "./types/store.d.ts",
   "exports": {
     "types": "./types/store.d.ts",
+    "require": "./dist/store.cjs",
     "import": "./dist/store.js"
   },
   "license": "MIT",
@@ -31,7 +32,9 @@
   ],
   "scripts": {
     "prepublishOnly": "run-s build types",
-    "build": "esbuild src/store.js --outfile=dist/store.js --target=es2017",
+    "build": "run-p build:*",
+    "build:cjs": "esbuild src/store.js --outfile=dist/store.cjs --target=es2017 --format=cjs",
+    "build:esm": "esbuild src/store.js --outfile=dist/store.js --target=es2017",
     "lint": "eslint . --ignore-pattern '/dist/'",
     "lint:fix": "eslint --fix . --ignore-pattern '/dist/'",
     "test": "node --test",


### PR DESCRIPTION
By popular demand 😄 A user has a large base of Jest tests where the ES-only module is causing problems.