### PR TITLE
fix: remove built-in $authentication store

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,29 +14,6 @@ To install:
 npm install @podium/store
 ```
 
-Use an [included store](#included-stores) in your client-side application:
-
-```js
-// store/user.js
-import { $authentication } from '@podium/store';
-import { computed } from 'nanostores';
-
-// You can optionally make a computed value based on the included store
-export const $loggedIn = computed($authentication, (authentication) =>
-    Boolean(authentication.token),
-);
-
-// Colocating actions with the store makes it easier to
-// see what can trigger updates.
-export function logIn(token) {
-    $authentication.set({ token });
-}
-
-export function logOut() {
-    $authentication.set({ token: null });
-}
-```
-
 Use the reactive store to do minimal updates of your UI when state changes. Nanostores supports multiple view frameworks:
 
 -   [React and Preact](https://github.com/nanostores/nanostores?tab=readme-ov-file#react--preact)
@@ -82,14 +59,6 @@ customElements.define('a-user', User);
 By using the [included helper](#mapchannel-topic-initialvalue) you can make your reactive state sync between the different parts of a Podium application.
 
 ## API
-
-### `$authentication`
-
-Type: [`map`](https://github.com/nanostores/nanostores?tab=readme-ov-file#maps)
-
-```js
-import { $authentication } from '@podium/store';
-```
 
 ### `atom(channel, topic, initialValue)`
 

--- a/src/store.js
+++ b/src/store.js
@@ -186,10 +186,3 @@ export function deepMap(channel, topic, initialValue) {
 
     return $store;
 }
-
-/**
- * @typedef {object} Authentication
- * @property {string | null} token The authentication token. `null` == not logged in.
- */
-
-export const $authentication = map('system', 'authentication', { token: null });

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -13,11 +13,7 @@ const dom = new JSDOM(html);
 globalThis.window = dom.window;
 
 const { MessageBus } = await import('@podium/browser');
-const { $authentication, atom, map, deepMap } = await import('../src/store.js');
-
-test('$authentication initial state', () => {
-    assert.deepStrictEqual($authentication.value, { token: null });
-});
+const { atom, map, deepMap } = await import('../src/store.js');
 
 test('atom returns a value connected to the Podium MessageBus', () => {
     const $reminders = atom('reminders', 'list', []);


### PR DESCRIPTION
This feature was intended to be an easier API for a built-in hybrid message[^1], but turned out to be problematic. By design the store will emit its value on the message bus if the message bus has no previous message for the channel and topic.

For authentication in a hybrid webview there is no client-side initial value (it's an Authorization HTTP request header). Unless a client-side script primes the message bus with a fake message on "system/authentication", this store ends up sending a signal to the native side that the user has logged out (authentication token is null).

Since the method to detect login state and prime the message bus will be different from case to case, this built-in store is removed.

BREAKING CHANGE: $authentication is removed

[1]: https://podium-lib.io/docs/guides/hybrid#message-contracts